### PR TITLE
Kleine Bugfixes

### DIFF
--- a/src/main/java/de/fraunhofer/igd/klarschiff/service/classification/FeatureService.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/service/classification/FeatureService.java
@@ -185,17 +185,15 @@ public class FeatureService {
           }
         } else if (attribute.isGeoAttribute()) {
           Double value = geoService.calculateFeature(vorgang.getOvi(), attribute);
-          if (value != null) {
-            logger.debug("createFeature fuer Vorgang Wert neu berechnen Ovi " + value.toString());
-          }
           if (value == null) {
             logger.debug("createFeature fuer Vorgang Wert neu berechnen Ovi null");
-          }
-          if (!(value > 0)) {
-            logger.debug("createFeature fuer Vorgang Wert neu berechnen Ovi 0 -> null");
-          }
-          if (value != null && value > 0) {
-            instance.setValue(attribute, value);
+          } else {
+            logger.debug("createFeature fuer Vorgang Wert neu berechnen Ovi " + value.toString());
+            if (value > 0) {
+              instance.setValue(attribute, value);
+            } else {
+              logger.debug("createFeature fuer Vorgang Wert neu berechnen Ovi 0 -> null");
+            }
           }
         } else {
           throw new Exception("Unbekanntes Feature: " + attribute.getName());

--- a/src/main/java/de/fraunhofer/igd/klarschiff/web/VorgangBearbeitenController.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/web/VorgangBearbeitenController.java
@@ -325,7 +325,7 @@ public class VorgangBearbeitenController {
 
     if (StringUtils.equals("wird nicht bearbeitet", cmd.getVorgang().getStatus().getText())) {
       assertNotEmpty(cmd, result, Assert.EvaluateOn.ever, "vorgang.statusKommentar",
-        "Für den Status wird nicht bearbeitet müssen Sie eine öffentliche Statusinformation angeben!");
+        "Für den Status „wird nicht bearbeitet“ müssen Sie eine öffentliche Statusinformation angeben!");
     }
 
     assertMaxLength(cmd, result, Assert.EvaluateOn.ever, "vorgang.statusKommentar",

--- a/src/main/java/de/fraunhofer/igd/klarschiff/web/VorgangSuchenController.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/web/VorgangSuchenController.java
@@ -220,7 +220,7 @@ public class VorgangSuchenController {
     if (cmd.suchtyp == Suchtyp.einfach && cmd.einfacheSuche == EinfacheSuche.offene) {
       modelMap.put("missbrauchsmeldungenAbgeschlossenenVorgaenge", vorgangDao.missbrauchsmeldungenAbgeschlossenenVorgaenge());
     }
-    modelMap.put("maxPages", calculateMaxPages(cmd.getSize(), ((List) modelMap.get("vorgaenge")).size()));
+    modelMap.put("maxPages", calculateMaxPages(cmd.getSize(), vorgangDao.countVorgaenge(cmd)));
 
     User user = securityService.getCurrentUser();
     if (user.getUserKoordinator()) {


### PR DESCRIPTION
* Beseitigung eines Encodingfehlers
* Cherry-Pick 2 Fixes aus HGW:
 * Vermeidung NullPointerException bei Debug-Log-Ausgabe
 * Blätterfunktion auf Suchdialog nach Umbauten für Redmine-Ticket #8 wieder funktionsfähig