### PR TITLE
Redmine #338, Performance für CitySDK-Anfragen und weitere kleine Fixes

### DIFF
--- a/src/main/java/de/fraunhofer/igd/klarschiff/dao/VorgangDao.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/dao/VorgangDao.java
@@ -668,7 +668,8 @@ public class VorgangDao {
     sql.append("SELECT vo.*,")
       .append(" verlauf1.datum AS aenderungsdatum,")
       .append(" COALESCE(un.count, 0) AS unterstuetzer,")
-      .append(" COALESCE(mi.count, 0) AS missbrauchsmeldung");
+      .append(" COALESCE(mi.count, 0) AS missbrauchsmeldung,")
+      .append(" statusdatum.datum AS statusdatum");
     sql.append(" FROM klarschiff_vorgang vo");
     // Für Sortierung
     sql.append(" LEFT JOIN klarschiff_kategorie kat_unter ON vo.kategorie = kat_unter.id");
@@ -678,6 +679,10 @@ public class VorgangDao {
     // Änderungsdatum
     sql.append(" INNER JOIN (SELECT vorgang, MAX(datum) AS datum FROM klarschiff_verlauf")
       .append(" GROUP BY vorgang) verlauf1 ON vo.id = verlauf1.vorgang");
+    // Status-Datum
+    sql.append(" LEFT JOIN (SELECT vorgang, MAX(datum) AS datum FROM klarschiff_verlauf")
+      .append(" WHERE typ IN ('status', 'erzeugt') GROUP BY vorgang) statusdatum ")
+      .append(" ON vo.id = statusdatum.vorgang");
 
     sql = addFilter(cmd, sql);
     // ORDER
@@ -699,8 +704,9 @@ public class VorgangDao {
       .createSQLQuery(sql.toString())
       .addEntity("vo", Vorgang.class)
       .addScalar("aenderungsdatum", StandardBasicTypes.DATE)
-      .addScalar("unterstuetzer", StandardBasicTypes.LONG)
+      .addScalar("unterstuetzer", StandardBasicTypes.INTEGER)
       .addScalar("missbrauchsmeldung", StandardBasicTypes.LONG)
+      .addScalar("statusdatum", StandardBasicTypes.DATE)
       .list();
   }
 

--- a/src/main/java/de/fraunhofer/igd/klarschiff/service/dbsync/DbSyncService.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/service/dbsync/DbSyncService.java
@@ -67,6 +67,7 @@ public class DbSyncService {
   String frontendDbDbName;
   String frontendDbUsername;
   String frontendDbPassword;
+  String frontendDbImageUrl;
   String backendDbHost;
   String backendDbPort;
   String backendDbSchema;
@@ -86,6 +87,7 @@ public class DbSyncService {
     scriptValuesMap.setProperty("f_username", getFrontendDbUsername());
     scriptValuesMap.setProperty("f_password", getFrontendDbPassword());
     scriptValuesMap.setProperty("b_username", getBackendDbUsername());
+    scriptValuesMap.setProperty("f_image_url", getFrontendDbImageUrl());
   }
 
   public Logger getLogger() {
@@ -290,6 +292,10 @@ public class DbSyncService {
     this.frontendDbPassword = frontendDbPassword;
   }
 
+  public void setFrontendDbImageUrl(String frontendDbImageUrl) {
+    this.frontendDbImageUrl = frontendDbImageUrl;
+  }
+
   public void setSqlScriptDbLinkFile(String sqlScriptDbLinkFile) {
     this.sqlScriptDbLinkFile = sqlScriptDbLinkFile;
   }
@@ -316,6 +322,10 @@ public class DbSyncService {
 
   public String getFrontendDbPassword() {
     return frontendDbPassword;
+  }
+
+  public String getFrontendDbImageUrl() {
+    return frontendDbImageUrl;
   }
 
   public String getSqlScriptFrontendDbFile() {

--- a/src/main/java/de/fraunhofer/igd/klarschiff/vo/Vorgang.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/vo/Vorgang.java
@@ -303,6 +303,12 @@ public class Vorgang implements Serializable {
   @OneToOne(mappedBy = "vorgang", cascade = CascadeType.ALL)
   private Auftrag auftrag;
 
+  @Transient
+  private long statusDatum;
+
+  @Transient
+  private Integer unterstuetzerCount;
+
   /**
    * Setzen der Position als WKT
    *
@@ -473,7 +479,8 @@ public class Vorgang implements Serializable {
   public Integer getTrustLevel() {
     int trust_level = 0;
 
-    if (getStatus() != EnumVorgangStatus.gemeldet) {
+    if (this.autorEmail.matches(settingsService.getPropertyValue("auth.internal_author_match"))
+      && getStatus() != EnumVorgangStatus.gemeldet) {
       trust_level = 1;
       if (autorAussendienst()) {
         trust_level = 3;
@@ -521,16 +528,11 @@ public class Vorgang implements Serializable {
   }
 
   public Integer getUnterstuetzerCount() {
-    if (this.unterstuetzer == null) {
-      return 0;
-    }
-    int unt = 0;
-    for (Unterstuetzer u : this.unterstuetzer) {
-      if (u.getDatumBestaetigung() != null) {
-        unt++;
-      }
-    }
-    return unt;
+    return this.unterstuetzerCount;
+  }
+
+  public void setUnterstuetzerCount(Integer unterstuetzerCount) {
+    this.unterstuetzerCount = unterstuetzerCount;
   }
 
   public void setUnterstuetzer(List<Unterstuetzer> unterstuetzer) {
@@ -572,15 +574,12 @@ public class Vorgang implements Serializable {
     this.statusOrdinal = status;
   }
 
-  public Date getStatusDatum() {
-    for (int i = verlauf.size() - 1; i >= 0; i--) {
-      Verlauf v = verlauf.get(i);
-      if (v.getTyp() == EnumVerlaufTyp.erzeugt || v.getTyp() == EnumVerlaufTyp.status) {
-        return v.getDatum();
-      }
-    }
+  public long getStatusDatum() {
+    return this.statusDatum;
+  }
 
-    return null;
+  public void setStatusDatum(long statusDatum) {
+    this.statusDatum = statusDatum;
   }
 
   public EnumZustaendigkeitStatus getZustaendigkeitStatus() {

--- a/src/main/java/de/fraunhofer/igd/klarschiff/vo/Vorgang.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/vo/Vorgang.java
@@ -102,6 +102,7 @@ public class Vorgang implements Serializable {
    * Information über das Eigentum des Flürstücks, in dem der Vorgang liegt
    */
   @Size(max = 300)
+  @JsonIgnore
   private String flurstueckseigentum;
 
   /**
@@ -129,12 +130,14 @@ public class Vorgang implements Serializable {
    * E-Mail-Adresse des Erstellers
    */
   @Size(max = 300)
+  @JsonIgnore
   private String autorEmail;
 
   /**
    * Hash zum Bestätigen des Vorganges
    */
   @Size(max = 32)
+  @JsonIgnore
   private String hash;
 
   /**
@@ -160,6 +163,7 @@ public class Vorgang implements Serializable {
   /**
    * Erstsichtung erfolgt
    */
+  @JsonIgnore
   private boolean erstsichtungErfolgt = false;
 
   /**
@@ -186,12 +190,14 @@ public class Vorgang implements Serializable {
   /**
    * Zuständigkeit (Id der Rolle) für den Vorgang
    */
+  @JsonIgnore
   String zustaendigkeit;
 
   /**
    * Status der Zuständigkeit
    */
   @Enumerated(EnumType.STRING)
+  @JsonIgnore
   EnumZustaendigkeitStatus zustaendigkeitStatus;
 
   /**
@@ -253,6 +259,7 @@ public class Vorgang implements Serializable {
    */
   @NotNull
   @Enumerated(EnumType.STRING)
+  @JsonIgnore
   EnumPrioritaet prioritaet;
 
   /**
@@ -265,6 +272,7 @@ public class Vorgang implements Serializable {
   /**
    * Flag zum Markieren archivierte Vorgänge
    */
+  @JsonIgnore
   Boolean archiviert;
 
   /**
@@ -326,6 +334,7 @@ public class Vorgang implements Serializable {
    * @return Position als WKT
    */
   @Transient
+  @JsonIgnore
   public String getOviWkt() {
     return (ovi == null) ? null : wktWriter.write(ovi);
   }
@@ -370,6 +379,7 @@ public class Vorgang implements Serializable {
    * @return <code>true</code> - es exisitiert eine Foto
    */
   @Transient
+  @JsonIgnore
   public boolean getFotoExists() {
     return (fotoNormal != null);
   }
@@ -701,6 +711,7 @@ public class Vorgang implements Serializable {
     this.auftrag = auftrag;
   }
 
+  @JsonIgnore
   public String getAuftragTeam() {
     if (getAuftrag() == null) {
       return null;

--- a/src/main/java/de/fraunhofer/igd/klarschiff/web/BackendController.java
+++ b/src/main/java/de/fraunhofer/igd/klarschiff/web/BackendController.java
@@ -1322,6 +1322,7 @@ public class BackendController {
         VorgangSuchenCommand cmd = new VorgangSuchenCommand();
         // Suchtyp aussendienst würde nur Vorgänge mit zustaendigkeit_status = 'akzeptiert' ausgeben
         cmd.setSuchtyp(VorgangSuchenCommand.Suchtyp.erweitert);
+        cmd.setErweitertArchiviert(false);
         // Sortieren nach ID
         cmd.setOrder(0);
         cmd.setOrderDirection(0);
@@ -1381,10 +1382,11 @@ public class BackendController {
           cmd.setAuftragDatum(new Date());
           cmd.setOrder(8);
         }
-
         List<Object[]> vg = vorgangDao.getVorgaenge(cmd);
         for (Object[] entry : vg) {
           Vorgang vorgang = (Vorgang) entry[0];
+          vorgang.setStatusDatum(((Date) entry[4]).getTime());
+          vorgang.setUnterstuetzerCount((Integer) entry[2]);
           vorgang.setSecurityService(securityService);
           vorgaenge.add(vorgang);
         }

--- a/src/main/resources/META-INF/spring/applicationContext-dbsync.xml
+++ b/src/main/resources/META-INF/spring/applicationContext-dbsync.xml
@@ -31,5 +31,6 @@
 		p:backendDbDbName="${database.dbname}"
 		p:backendDbUsername="${database.username}"
 		p:backendDbPassword="${database.password}"
+		p:frontendDbImageUrl="${image.url}"
 	/>
 </beans>

--- a/src/main/resources/META-INF/spring/applicationContext-security.xml
+++ b/src/main/resources/META-INF/spring/applicationContext-security.xml
@@ -36,6 +36,7 @@
         <secure:intercept-url pattern="/vorgangneu" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_INTERN')" />
         <secure:intercept-url pattern="/kategorien/**" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_INTERN')" />
         <secure:intercept-url pattern="/" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_INTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_KOORDINATOR') or hasRole('ROLE_AUSSENDIENST')"/>
+        <secure:intercept-url pattern="/vorgang/delegiert/**" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_INTERN') or hasRole('ROLE_ADMIN')" /> 
         <secure:intercept-url pattern="/aussendienst/**" access="hasRole('ROLE_KOORDINATOR')" />
         <secure:intercept-url pattern="/auftragsliste/**" access="hasRole('ROLE_AUSSENDIENST')" />
         <secure:intercept-url pattern="/**" access="hasRole('ROLE_INTERN') or hasRole('ROLE_ADMIN')" />

--- a/src/main/resources/META-INF/spring/applicationContext-security.xml
+++ b/src/main/resources/META-INF/spring/applicationContext-security.xml
@@ -36,7 +36,6 @@
         <secure:intercept-url pattern="/vorgangneu" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_INTERN')" />
         <secure:intercept-url pattern="/kategorien/**" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_INTERN')" />
         <secure:intercept-url pattern="/" access="hasRole('ROLE_EXTERN') or hasRole('ROLE_INTERN') or hasRole('ROLE_ADMIN') or hasRole('ROLE_KOORDINATOR') or hasRole('ROLE_AUSSENDIENST')"/>
-        <secure:intercept-url pattern="/vorgang/delegiert/**" access="permitAll" />
         <secure:intercept-url pattern="/aussendienst/**" access="hasRole('ROLE_KOORDINATOR')" />
         <secure:intercept-url pattern="/auftragsliste/**" access="hasRole('ROLE_AUSSENDIENST')" />
         <secure:intercept-url pattern="/**" access="hasRole('ROLE_INTERN') or hasRole('ROLE_ADMIN')" />

--- a/src/main/resources/META-INF/sql/sqlScript.FrontendDb.sql
+++ b/src/main/resources/META-INF/sql/sqlScript.FrontendDb.sql
@@ -344,7 +344,7 @@ CREATE OR REPLACE VIEW klarschiff_wfs_georss AS
             ELSE 'nicht vorhanden'::text
         END AS beschreibung,
         CASE
-            WHEN v.foto_thumb IS NOT NULL AND v.foto_thumb::text <> ''::text AND v.foto_freigegeben IS TRUE AND v.foto_vorhanden IS TRUE THEN ((((('<br/><a href="http://support.klarschiff-hro.de/fotos/'::text || v.foto_normal::text) || '" target="_blank" title="große Ansicht öffnen…"><img src="http://support.klarschiff-hro.de/fotos/'::text) || v.foto_thumb::text) || '" alt="'::text) || v.foto_thumb::text) || '" /></a>'::text
+            WHEN v.foto_thumb IS NOT NULL AND v.foto_thumb::text <> ''::text AND v.foto_freigegeben IS TRUE AND v.foto_vorhanden IS TRUE THEN ((((('<br/><a href="${f_image_url}'::text || v.foto_normal::text) || '" target="_blank" title="große Ansicht öffnen…"><img src="${f_image_url}'::text) || v.foto_thumb::text) || '" alt="'::text) || v.foto_thumb::text) || '" /></a>'::text
             WHEN v.status::text = 'offen'::text AND v.foto_vorhanden IS TRUE AND v.foto_freigegeben IS FALSE THEN 'redaktionelle Prüfung ausstehend'::text
             WHEN v.status::text <> 'offen'::text AND v.foto_vorhanden IS TRUE AND v.foto_freigegeben IS FALSE THEN 'redaktionell nicht freigegeben'::text
             ELSE 'nicht vorhanden'::text
@@ -359,7 +359,7 @@ CREATE OR REPLACE VIEW klarschiff_wfs_georss AS
         END AS datum,
         ST_X(ST_Transform(v.the_geom, 4326))::text AS x,
         ST_Y(ST_Transform(v.the_geom, 4326))::text AS y,
-        v.the_geom::geometry(Point,25833) AS geometrie
+        v.the_geom::geometry(Point, 25833) AS geometrie
     FROM
         klarschiff.klarschiff_vorgang v,
         klarschiff.klarschiff_kategorie hk,

--- a/src/main/resources/settings.sample.properties
+++ b/src/main/resources/settings.sample.properties
@@ -36,7 +36,6 @@ database.frontend.schema=klarschiff
 database.frontend.dbname=klarschiff_frontend
 database.frontend.username=benutzer
 database.frontend.password=passwort
-database.frontend.extrascriptparams=f_exportimage_path=/pfad/zu/den/fotos/
 
 ############# initialisierende Datenbankskripte für dblink und Frontend-Datenbank #############
 init.sqlscript.frontenddb=warn

--- a/src/main/webapp/WEB-INF/views/admin/zertifikate.jspx
+++ b/src/main/webapp/WEB-INF/views/admin/zertifikate.jspx
@@ -30,7 +30,7 @@
 			<div>
 				<p class="help">
 					Unter Windows 7 muss der Tomcat mit Adminrechten gestartet werden, damit der Befehl korrekt ausgeführt werden kann 
-					und UAC (User Account Control, dt. Benutzerkontensteuerung) nicht dazwischenfuscht. 
+					und es nicht zu Problemen mit UAC (User Account Control, dt. Benutzerkontensteuerung) kommt. 
 					<br/>
 					Das Standardpasswort für den Java-Keystore lautet: changeit. Weiterführende Informationen zum Java-Keystore sind <a href="http://download.oracle.com/javase/6/docs/technotes/tools/solaris/keytool.html" target="_blank">hier</a> zu finden.
 				</p>


### PR DESCRIPTION
* Berechtigungsproblem aus Redmine #338
* Verwendung des Parameters aus der `settings.properties` für die Image-Url in der View
* nicht mehr notwendigen Parameter aus `settings.properties` entfernt
* Patch zur Optimierung der Ladezeit bei vielen Meldungen als Liste
* Bessere Formulierung bei Hinweis auf UAC auf der Zertifikate-Seite im Adminbereich